### PR TITLE
Change approach to avoiding class name conflicts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(name='svgimgutils',
                        ''
                        'SVG Image Utils modifies attributes that contradict each other between all the appended SVGs and thus outputs a'
                        'new, intuitive looking layered SVG image.',
-      version='0.1.0',
+      version='0.1.1',
       py_modules=['svgimgutils'],
       install_requires=[
           'lxml',


### PR DESCRIPTION
This solutions generates a pseudo-random string for each `SVGImgUtils` element and uses that to avoid class name conflicts in merged SVGs by prepending it to each class. 6^26 should be more than enough for any reasonable layering of SVGs.